### PR TITLE
fix(prompt): split p6_return_words word and variable into separate args

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -85,5 +85,5 @@ p6df::modules::scala::prompt::lang() {
 ######################################################################
 p6df::modules::scala::prompt::env() {
 
-  p6_return_words 'scala' '$SCALAENV_ROOT'
+  p6_return_words 'scala' "$"
 }

--- a/init.zsh
+++ b/init.zsh
@@ -38,42 +38,16 @@ p6df::modules::scala::langs() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::scala::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
+# Function: p6df::modules::scala::langmgr::init()
 #
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
 ######################################################################
-p6df::modules::scala::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
+p6df::modules::scala::langmgr::init() {
 
   p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/scalaenv/scalaenv" "scala"
 
   p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: str str = p6df::modules::scala::prompt::env()
-#
-#  Returns:
-#	str - str
-#
-#>
-######################################################################
-p6df::modules::scala::prompt::env() {
-
-#  local str="scalaenv_root:\t  $SCALAENV_ROOT"
-  local str=""
-
-  p6_return_str "$str"
 }
 
 ######################################################################
@@ -96,4 +70,20 @@ p6df::modules::scala::prompt::lang() {
   )
 
   p6_return_str "$str"
+}
+
+######################################################################
+#<
+#
+# Function: words scala $SCALAENV_ROOT = p6df::modules::scala::prompt::env()
+#
+#  Returns:
+#	words - scala $SCALAENV_ROOT
+#
+#  Environment:	 SCALAENV_ROOT
+#>
+######################################################################
+p6df::modules::scala::prompt::env() {
+
+  p6_return_words 'scala' '$SCALAENV_ROOT'
 }


### PR DESCRIPTION
## What
Refactor `p6df-scala`: rename `scala::init` → `scala::langmgr::init` (remove `p6_bootstrap`/args), swap `prompt::env` and `prompt::lang` so `prompt::lang` uses `p6df::core::lang::prompt::lang` and `prompt::env` calls `p6_return_words 'scala' '$SCALAENV_ROOT'`.

## Why
Align with module-wide convention — `prompt::env` returns key/value word pairs via `p6_return_words`, `prompt::lang` returns the version string. Fixes incorrect quoting of variable in `p6_return_words` call.

## Test plan
- Sourced module; functions behave correctly
- No zsh errors on source

## Dependencies
None