### PR TITLE
fix(scala): fix prompt::env to return SCALAENV_ROOT env var

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -85,5 +85,5 @@ p6df::modules::scala::prompt::lang() {
 ######################################################################
 p6df::modules::scala::prompt::env() {
 
-  p6_return_words 'scala' "$"
+  p6_return_words 'scala' '$SCALAENV_ROOT'
 }


### PR DESCRIPTION
## What
Fix `prompt::env` to return `'$SCALAENV_ROOT'` instead of a broken `"$"`.

## Why
The return value was broken — returning a literal `"$"` instead of the env var reference `'$SCALAENV_ROOT'`. This caused the prompt to display incorrect information.

## Test plan
- Verified diff is correct
- Function now returns `scala $SCALAENV_ROOT` as expected by the prompt system

## Dependencies
None