### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::scala::deps()
+#
+#>
+######################################################################
 p6df::modules::scala::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -8,6 +14,13 @@ p6df::modules::scala::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::scala::langmgr::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
+######################################################################
 p6df::modules::scala::langmgr::init() {
 
   p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/scalaenv/scalaenv" "scala"
@@ -15,6 +28,12 @@ p6df::modules::scala::langmgr::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::scala::langs()
+#
+#>
 ######################################################################
 p6df::modules::scala::langs() {
 
@@ -31,25 +50,6 @@ p6df::modules::scala::langs() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::scala::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::scala::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::scala::langmgr::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::scala::deps()
-#
-#>
-######################################################################
 p6df::modules::scala::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -14,11 +8,13 @@ p6df::modules::scala::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::scala::langs()
-#
-#>
+p6df::modules::scala::langmgr::init() {
+
+  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/scalaenv/scalaenv" "scala"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::scala::langs() {
 
@@ -38,18 +34,22 @@ p6df::modules::scala::langs() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::scala::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::scala::langs()
+#
+#>
+######################################################################
+#<
+#
 # Function: p6df::modules::scala::langmgr::init()
 #
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
-######################################################################
-p6df::modules::scala::langmgr::init() {
-
-  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/scalaenv/scalaenv" "scala"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None