### PR TITLE
refactor(scala): update function signatures and rename prompt::env return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,10 @@ TODO: Add a short summary of this module.
 ##### p6df-scala/init.zsh
 
 - `p6df::modules::scala::deps()`
-- `p6df::modules::scala::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
+- `p6df::modules::scala::langmgr::init()`
 - `p6df::modules::scala::langs()`
-- `str str = p6df::modules::scala::prompt::env()`
 - `str str = p6df::modules::scala::prompt::lang()`
+- `words scala = p6df::modules::scala::prompt::env()`
 
 #### p6df-scala/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -75,10 +75,10 @@ p6df::modules::scala::prompt::lang() {
 ######################################################################
 #<
 #
-# Function: words scala $SCALAENV_ROOT = p6df::modules::scala::prompt::env()
+# Function: words scala = p6df::modules::scala::prompt::env()
 #
 #  Returns:
-#	words - scala $SCALAENV_ROOT
+#	words - scala
 #
 #  Environment:	 SCALAENV_ROOT
 #>


### PR DESCRIPTION
**What:** Update function signatures and fix prompt::env return type declaration

**Why:** Normalizes function documentation to use consistent `words scala` return type and adds `langmgr::init`

**Test plan:** Shell loads without errors; scala prompt functions return expected values

**Dependencies:** none